### PR TITLE
Fix failing tests on master

### DIFF
--- a/examples/deployment/py/__main__.py
+++ b/examples/deployment/py/__main__.py
@@ -8,5 +8,5 @@ latest_version = ec.get_stack(
     region=REGION, version_regex="latest").version
 
 deployment = ec.Deployment('my-deployment', region=REGION, version=latest_version,
-                           deployment_template_id="aws-io-optimized-v2",
+                           deployment_template_id="aws-general-purpose-arm",
                            elasticsearch={ "hot": { "autoscaling": {} } })

--- a/examples/deployment/ts/index.ts
+++ b/examples/deployment/ts/index.ts
@@ -4,12 +4,12 @@ const REGION = "us-east-1";
 
 const latestVersion = elasticCloud.getStack({
   region: REGION,
-  versionRegex: "latest"
+  versionRegex: "latest",
 });
 
-new elasticCloud.Deployment('my-deployment', {
+new elasticCloud.Deployment("my-deployment", {
   region: REGION,
-  version: latestVersion.then((x: { version: string; }) => x.version),
-  deploymentTemplateId: "aws-io-optimized-v2",
+  version: latestVersion.then((x: { version: string }) => x.version),
+  deploymentTemplateId: "aws-general-purpose-arm",
   elasticsearch: { hot: { autoscaling: {} } },
 });


### PR DESCRIPTION
The `aws-io-optimized-v2` template has been deprecated.

https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html#ec-aws_regions