### PR TITLE
Fix #147: auto-migrate legacy string elasticsearch.autoscale in state

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -41,6 +41,8 @@ const (
 	mainPkg = "ec"
 	// modules:
 	mainMod = "index" // the y module
+
+	elasticsearchKey = "elasticsearch"
 )
 
 //go:embed  cmd/pulumi-resource-ec/bridge-metadata.json
@@ -139,7 +141,7 @@ func Provider() tfbridge.ProviderInfo {
 // current schema expects. Values that are already booleans (or absent) are left
 // untouched, so the transform is a no-op on clean state. See issue #147.
 func migrateElasticsearchAutoscale(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
-	es, ok := state["elasticsearch"]
+	es, ok := state[elasticsearchKey]
 	if !ok {
 		return state, nil
 	}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -15,9 +15,11 @@
 package ec
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	// Allow us to embed metadata
 	_ "embed"
@@ -28,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/pulumi/pulumi-ec/provider/pkg/version"
 )
@@ -107,11 +110,64 @@ func Provider() tfbridge.ProviderInfo {
 	prov.MustComputeTokens(tks.SingleModule("ec_", mainMod,
 		tks.MakeStandard(mainPkg)))
 
+	// https://github.com/pulumi/pulumi-ec/issues/147
+	//
+	// terraform-provider-ec changed `elasticsearch.autoscale` from a string to a bool
+	// (released in pulumi-ec v0.6.0). Stacks first deployed with <= 0.5.x have the value
+	// stored in Pulumi state as a JSON string ("true"/"false"). When a newer provider
+	// reads that state the schema encoder throws before any cloud call:
+	//
+	//   [pf/tfbridge] Error calling EncodePropertyMap: objectEncoder failed on property
+	//   "elasticsearch": objectEncoder failed on property "autoscale": Expected a Boolean
+	//
+	// TransformFromState runs on the prior state ahead of the encode/upgrade steps in
+	// Check, Diff, Read, Update and Delete, so coercing the legacy string to a bool here
+	// migrates affected stacks transparently — no manual `pulumi state` surgery required.
+	if r := prov.Resources["ec_deployment"]; r != nil {
+		r.TransformFromState = migrateElasticsearchAutoscale
+	}
+
 	prov.SetAutonaming(255, "-")
 
 	prov.MustApplyAutoAliases()
 
 	return prov
+}
+
+// migrateElasticsearchAutoscale coerces a legacy string `elasticsearch.autoscale`
+// (e.g. "true"/"false", as written by pulumi-ec <= 0.5.x) into the boolean that the
+// current schema expects. Values that are already booleans (or absent) are left
+// untouched, so the transform is a no-op on clean state. See issue #147.
+func migrateElasticsearchAutoscale(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+	es, ok := state["elasticsearch"]
+	if !ok {
+		return state, nil
+	}
+
+	coerce := func(v resource.PropertyValue) resource.PropertyValue {
+		if !v.IsObject() {
+			return v
+		}
+		obj := v.ObjectValue()
+		if a, ok := obj["autoscale"]; ok && a.IsString() {
+			obj["autoscale"] = resource.NewBoolProperty(strings.EqualFold(a.StringValue(), "true"))
+		}
+		return resource.NewObjectProperty(obj)
+	}
+
+	switch {
+	case es.IsObject():
+		state["elasticsearch"] = coerce(es)
+	case es.IsArray():
+		// Older schema shapes modelled elasticsearch as a single-element list.
+		arr := es.ArrayValue()
+		for i := range arr {
+			arr[i] = coerce(arr[i])
+		}
+		state["elasticsearch"] = resource.NewArrayProperty(arr)
+	}
+
+	return state, nil
 }
 
 func docEditRules(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/pulumi/pulumi-ec/provider/pkg/version"
 )
@@ -33,21 +34,21 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 
 	es := func(autoscale resource.PropertyValue) resource.PropertyMap {
 		return resource.PropertyMap{
-			"elasticsearch": resource.NewObjectProperty(resource.PropertyMap{
+			elasticsearchKey: resource.NewObjectProperty(resource.PropertyMap{
 				"autoscale": autoscale,
 				"hot":       resource.NewObjectProperty(resource.PropertyMap{"size": resource.NewStringProperty("8g")}),
 			}),
 		}
 	}
-	autoscaleOf := func(t *testing.T, m resource.PropertyMap) resource.PropertyValue {
-		return m["elasticsearch"].ObjectValue()["autoscale"]
+	autoscaleOf := func(m resource.PropertyMap) resource.PropertyValue {
+		return m[elasticsearchKey].ObjectValue()["autoscale"]
 	}
 
 	t.Run("string false -> bool false", func(t *testing.T) {
 		t.Parallel()
 		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("false")))
 		require.NoError(t, err)
-		got := autoscaleOf(t, out)
+		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
 		assert.False(t, got.BoolValue())
 	})
@@ -56,7 +57,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 		t.Parallel()
 		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("TRUE")))
 		require.NoError(t, err)
-		got := autoscaleOf(t, out)
+		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
 		assert.True(t, got.BoolValue())
 	})
@@ -65,7 +66,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 		t.Parallel()
 		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewBoolProperty(true)))
 		require.NoError(t, err)
-		got := autoscaleOf(t, out)
+		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
 		assert.True(t, got.BoolValue())
 	})
@@ -73,13 +74,13 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 	t.Run("single-element list shape", func(t *testing.T) {
 		t.Parallel()
 		in := resource.PropertyMap{
-			"elasticsearch": resource.NewArrayProperty([]resource.PropertyValue{
+			elasticsearchKey: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewObjectProperty(resource.PropertyMap{"autoscale": resource.NewStringProperty("true")}),
 			}),
 		}
 		out, err := migrateElasticsearchAutoscale(context.Background(), in)
 		require.NoError(t, err)
-		got := out["elasticsearch"].ArrayValue()[0].ObjectValue()["autoscale"]
+		got := out[elasticsearchKey].ArrayValue()[0].ObjectValue()["autoscale"]
 		require.True(t, got.IsBool())
 		assert.True(t, got.BoolValue())
 	})

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-ec/provider/pkg/version"
+)
+
+// TestMigrateElasticsearchAutoscale covers the state migration for
+// https://github.com/pulumi/pulumi-ec/issues/147: legacy stacks store
+// elasticsearch.autoscale as a string, the current schema expects a bool.
+func TestMigrateElasticsearchAutoscale(t *testing.T) {
+	t.Parallel()
+
+	es := func(autoscale resource.PropertyValue) resource.PropertyMap {
+		return resource.PropertyMap{
+			"elasticsearch": resource.NewObjectProperty(resource.PropertyMap{
+				"autoscale": autoscale,
+				"hot":       resource.NewObjectProperty(resource.PropertyMap{"size": resource.NewStringProperty("8g")}),
+			}),
+		}
+	}
+	autoscaleOf := func(t *testing.T, m resource.PropertyMap) resource.PropertyValue {
+		return m["elasticsearch"].ObjectValue()["autoscale"]
+	}
+
+	t.Run("string false -> bool false", func(t *testing.T) {
+		t.Parallel()
+		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("false")))
+		require.NoError(t, err)
+		got := autoscaleOf(t, out)
+		require.True(t, got.IsBool())
+		assert.False(t, got.BoolValue())
+	})
+
+	t.Run("string true -> bool true (case-insensitive)", func(t *testing.T) {
+		t.Parallel()
+		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("TRUE")))
+		require.NoError(t, err)
+		got := autoscaleOf(t, out)
+		require.True(t, got.IsBool())
+		assert.True(t, got.BoolValue())
+	})
+
+	t.Run("already bool is left untouched (idempotent)", func(t *testing.T) {
+		t.Parallel()
+		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewBoolProperty(true)))
+		require.NoError(t, err)
+		got := autoscaleOf(t, out)
+		require.True(t, got.IsBool())
+		assert.True(t, got.BoolValue())
+	})
+
+	t.Run("single-element list shape", func(t *testing.T) {
+		t.Parallel()
+		in := resource.PropertyMap{
+			"elasticsearch": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{"autoscale": resource.NewStringProperty("true")}),
+			}),
+		}
+		out, err := migrateElasticsearchAutoscale(context.Background(), in)
+		require.NoError(t, err)
+		got := out["elasticsearch"].ArrayValue()[0].ObjectValue()["autoscale"]
+		require.True(t, got.IsBool())
+		assert.True(t, got.BoolValue())
+	})
+
+	t.Run("missing elasticsearch is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := resource.PropertyMap{"region": resource.NewStringProperty("gcp-europe-west1")}
+		out, err := migrateElasticsearchAutoscale(context.Background(), in)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
+	})
+}
+
+// TestAutoscaleTransformIsWired guards against the hook silently detaching if the
+// resource token mapping changes (e.g. the Resources map key is no longer populated).
+func TestAutoscaleTransformIsWired(t *testing.T) {
+	t.Parallel()
+	version.Version = "0.0.0-test"
+	p := Provider()
+	r := p.Resources["ec_deployment"]
+	require.NotNil(t, r, "ec_deployment must be present in the Resources map")
+	assert.NotNil(t, r.TransformFromState, "TransformFromState must be set on ec_deployment")
+}


### PR DESCRIPTION
Stacks first deployed with pulumi-ec ≤ 0.5.x stored autoscale as a string; since 0.6.0 the schema expects a bool, so reading old state throws objectEncoder failed on property "autoscale": Expected a Boolean — blocking up, preview, and refresh with no fix short of manual state editing.

Adds a TransformFromState hook on ec_deployment that coerces the legacy string to a bool before the encode step (idempotent; handles object and list shapes). Affected stacks self-heal on next operation.

Tested with new unit tests in provider/resources_test.go; make tfgen yields no schema diff (runtime-only). Fixes #147