### PR TITLE
Re-fix #147: add PreStateUpgradeHook and coerce v1 autoscale/strategy shapes

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -112,36 +112,12 @@ func Provider() tfbridge.ProviderInfo {
 	prov.MustComputeTokens(tks.SingleModule("ec_", mainMod,
 		tks.MakeStandard(mainPkg)))
 
-	// https://github.com/pulumi/pulumi-ec/issues/147
-	//
-	// terraform-provider-ec changed `elasticsearch.autoscale` from a string to a bool
-	// (released in pulumi-ec v0.6.0). Stacks first deployed with <= 0.5.x have the value
-	// stored in Pulumi state as a JSON string ("true"/"false"). When a newer provider
-	// reads that state the schema encoder throws before any cloud call:
-	//
-	//   [pf/tfbridge] Error calling EncodePropertyMap: objectEncoder failed on property
-	//   "elasticsearch": objectEncoder failed on property "autoscale": Expected a Boolean
-	//
-	// TransformFromState runs on the prior state ahead of the encode/upgrade steps in
-	// Check, Diff, Read, Update and Delete, so coercing the legacy string to a bool here
-	// migrates affected stacks transparently — no manual `pulumi state` surgery required.
+	// The Elastic Cloud deployment resource has two breaking schema changes from v1 to v2; transform them and
+	// update the schema version
 	if r := prov.Resources["ec_deployment"]; r != nil {
 		r.TransformFromState = migrateElasticsearchState
 
-		// Upstream ec_deployment declares schema version 2 but ships no
-		// StateUpgrader, so the Plugin Framework runtime rejects any prior state
-		// recorded at an older version with:
-		//
-		//   This resource was implemented without an UpgradeState() method,
-		//   however Terraform was expecting an implementation for version N upgrade.
-		//   ... Unable to Upgrade Resource State
-		//
-		// TransformFromState has already coerced the only breaking field
-		// (elasticsearch.autoscale string -> bool), so the prior state is already
-		// shaped for the current schema. Report it as already at the current
-		// version so the bridge invokes UpgradeResourceState with version ==
-		// current, which the framework treats as a pass-through and does not
-		// require an upgrader.
+		// The upstream ec_deployment has no StateUpgrader; provide one
 		r.PreStateUpgradeHook = func(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
 			return args.ResourceSchemaVersion, args.PriorState, nil
 		}
@@ -154,26 +130,16 @@ func Provider() tfbridge.ProviderInfo {
 	return prov
 }
 
-// migrateElasticsearchState coerces legacy `elasticsearch` field shapes (as written
-// by pulumi-ec <= 0.5.x against the v1 upstream schema) into the shapes the current
-// (v2) schema expects, so the prior state can be encoded against it. See issue #147.
-//
-// Two fields changed shape between the v1 and v2 schemas in a way the encoder cannot
-// reconcile on its own:
-//
-//   - `autoscale`: string ("true"/"false") -> bool.
-//   - `strategy`:  list/object of `{type: "..."}` -> the bare `type` string.
-//
-// Values already in the current shape (or absent) are left untouched, so the
-// transform is idempotent and a no-op on clean state.
+// migrateElasticsearchState coerces `elasticsearch` field shapes from v1 -> v2 schema.
+// Changes only `autoscale` and `strategy` fields to match the upstream provider.
 func migrateElasticsearchState(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
 	es, ok := state[elasticsearchKey]
 	if !ok {
 		return state, nil
 	}
 
-	// extractStrategyType pulls the `type` string out of a legacy `strategy` value,
-	// which the v1 schema modelled as a (single-element) list of `{type: "..."}`
+	// extractStrategyType pulls the `type` string out of the `strategy` value,
+	// which the v1 schema modeled as a (single-element) list of `{type: "..."}`
 	// objects, or as a single such object. Returns false if no string type is found.
 	extractStrategyType := func(v resource.PropertyValue) (string, bool) {
 		if v.IsArray() {
@@ -211,7 +177,7 @@ func migrateElasticsearchState(_ context.Context, state resource.PropertyMap) (r
 	case es.IsObject():
 		state["elasticsearch"] = coerce(es)
 	case es.IsArray():
-		// Older schema shapes modelled elasticsearch as a single-element list.
+		// Older schema shapes modeled elasticsearch as a single-element list.
 		arr := es.ArrayValue()
 		for i := range arr {
 			arr[i] = coerce(arr[i])

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -126,7 +126,25 @@ func Provider() tfbridge.ProviderInfo {
 	// Check, Diff, Read, Update and Delete, so coercing the legacy string to a bool here
 	// migrates affected stacks transparently — no manual `pulumi state` surgery required.
 	if r := prov.Resources["ec_deployment"]; r != nil {
-		r.TransformFromState = migrateElasticsearchAutoscale
+		r.TransformFromState = migrateElasticsearchState
+
+		// Upstream ec_deployment declares schema version 2 but ships no
+		// StateUpgrader, so the Plugin Framework runtime rejects any prior state
+		// recorded at an older version with:
+		//
+		//   This resource was implemented without an UpgradeState() method,
+		//   however Terraform was expecting an implementation for version N upgrade.
+		//   ... Unable to Upgrade Resource State
+		//
+		// TransformFromState has already coerced the only breaking field
+		// (elasticsearch.autoscale string -> bool), so the prior state is already
+		// shaped for the current schema. Report it as already at the current
+		// version so the bridge invokes UpgradeResourceState with version ==
+		// current, which the framework treats as a pass-through and does not
+		// require an upgrader.
+		r.PreStateUpgradeHook = func(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+			return args.ResourceSchemaVersion, args.PriorState, nil
+		}
 	}
 
 	prov.SetAutonaming(255, "-")
@@ -136,14 +154,41 @@ func Provider() tfbridge.ProviderInfo {
 	return prov
 }
 
-// migrateElasticsearchAutoscale coerces a legacy string `elasticsearch.autoscale`
-// (e.g. "true"/"false", as written by pulumi-ec <= 0.5.x) into the boolean that the
-// current schema expects. Values that are already booleans (or absent) are left
-// untouched, so the transform is a no-op on clean state. See issue #147.
-func migrateElasticsearchAutoscale(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+// migrateElasticsearchState coerces legacy `elasticsearch` field shapes (as written
+// by pulumi-ec <= 0.5.x against the v1 upstream schema) into the shapes the current
+// (v2) schema expects, so the prior state can be encoded against it. See issue #147.
+//
+// Two fields changed shape between the v1 and v2 schemas in a way the encoder cannot
+// reconcile on its own:
+//
+//   - `autoscale`: string ("true"/"false") -> bool.
+//   - `strategy`:  list/object of `{type: "..."}` -> the bare `type` string.
+//
+// Values already in the current shape (or absent) are left untouched, so the
+// transform is idempotent and a no-op on clean state.
+func migrateElasticsearchState(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
 	es, ok := state[elasticsearchKey]
 	if !ok {
 		return state, nil
+	}
+
+	// extractStrategyType pulls the `type` string out of a legacy `strategy` value,
+	// which the v1 schema modelled as a (single-element) list of `{type: "..."}`
+	// objects, or as a single such object. Returns false if no string type is found.
+	extractStrategyType := func(v resource.PropertyValue) (string, bool) {
+		if v.IsArray() {
+			arr := v.ArrayValue()
+			if len(arr) == 0 {
+				return "", false
+			}
+			v = arr[0]
+		}
+		if v.IsObject() {
+			if t, ok := v.ObjectValue()["type"]; ok && t.IsString() {
+				return t.StringValue(), true
+			}
+		}
+		return "", false
 	}
 
 	coerce := func(v resource.PropertyValue) resource.PropertyValue {
@@ -153,6 +198,11 @@ func migrateElasticsearchAutoscale(_ context.Context, state resource.PropertyMap
 		obj := v.ObjectValue()
 		if a, ok := obj["autoscale"]; ok && a.IsString() {
 			obj["autoscale"] = resource.NewBoolProperty(strings.EqualFold(a.StringValue(), "true"))
+		}
+		if s, ok := obj["strategy"]; ok && !s.IsString() {
+			if t, got := extractStrategyType(s); got {
+				obj["strategy"] = resource.NewStringProperty(t)
+			}
 		}
 		return resource.NewObjectProperty(obj)
 	}

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -26,10 +26,9 @@ import (
 	"github.com/pulumi/pulumi-ec/provider/pkg/version"
 )
 
-// TestMigrateElasticsearchAutoscale covers the state migration for
-// https://github.com/pulumi/pulumi-ec/issues/147: legacy stacks store
-// elasticsearch.autoscale as a string, the current schema expects a bool.
-func TestMigrateElasticsearchAutoscale(t *testing.T) {
+// Ensure https://github.com/pulumi/pulumi-ec/issues/147 schema migration
+// v1 stacks store elasticsearch.autoscale as a string, the current schema expects a bool.
+func TestMigrateElasticCloudDeploymentAutoscale(t *testing.T) {
 	t.Parallel()
 
 	es := func(autoscale resource.PropertyValue) resource.PropertyMap {
@@ -94,10 +93,9 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 	})
 }
 
-// TestMigrateElasticsearchStrategy covers the second v1->v2 shape change: the
-// legacy `strategy` field was a (single-element) list of `{type: "..."}` objects,
-// while the current schema models it as the bare `type` string.
-func TestMigrateElasticsearchStrategy(t *testing.T) {
+// v1 stacks store elasticsearch.strategy as a single-element) list of `{type: "..."}` objects
+// The current schema expects a bare `type` string.
+func TestMigrateElasticCloudDeploymentStrategy(t *testing.T) {
 	t.Parallel()
 
 	es := func(strategy resource.PropertyValue) resource.PropertyMap {
@@ -151,9 +149,7 @@ func TestMigrateElasticsearchStrategy(t *testing.T) {
 	})
 }
 
-// TestAutoscaleTransformIsWired guards against the hook silently detaching if the
-// resource token mapping changes (e.g. the Resources map key is no longer populated).
-func TestAutoscaleTransformIsWired(t *testing.T) {
+func TestElasticCloudDeploymentSchemaMigrationTransformIsWired(t *testing.T) {
 	t.Parallel()
 	version.Version = "0.0.0-test"
 	p := Provider()

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -46,7 +46,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 
 	t.Run("string false -> bool false", func(t *testing.T) {
 		t.Parallel()
-		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("false")))
+		out, err := migrateElasticsearchState(context.Background(), es(resource.NewStringProperty("false")))
 		require.NoError(t, err)
 		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
@@ -55,7 +55,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 
 	t.Run("string true -> bool true (case-insensitive)", func(t *testing.T) {
 		t.Parallel()
-		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewStringProperty("TRUE")))
+		out, err := migrateElasticsearchState(context.Background(), es(resource.NewStringProperty("TRUE")))
 		require.NoError(t, err)
 		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
@@ -64,7 +64,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 
 	t.Run("already bool is left untouched (idempotent)", func(t *testing.T) {
 		t.Parallel()
-		out, err := migrateElasticsearchAutoscale(context.Background(), es(resource.NewBoolProperty(true)))
+		out, err := migrateElasticsearchState(context.Background(), es(resource.NewBoolProperty(true)))
 		require.NoError(t, err)
 		got := autoscaleOf(out)
 		require.True(t, got.IsBool())
@@ -78,7 +78,7 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 				resource.NewObjectProperty(resource.PropertyMap{"autoscale": resource.NewStringProperty("true")}),
 			}),
 		}
-		out, err := migrateElasticsearchAutoscale(context.Background(), in)
+		out, err := migrateElasticsearchState(context.Background(), in)
 		require.NoError(t, err)
 		got := out[elasticsearchKey].ArrayValue()[0].ObjectValue()["autoscale"]
 		require.True(t, got.IsBool())
@@ -88,9 +88,66 @@ func TestMigrateElasticsearchAutoscale(t *testing.T) {
 	t.Run("missing elasticsearch is a no-op", func(t *testing.T) {
 		t.Parallel()
 		in := resource.PropertyMap{"region": resource.NewStringProperty("gcp-europe-west1")}
-		out, err := migrateElasticsearchAutoscale(context.Background(), in)
+		out, err := migrateElasticsearchState(context.Background(), in)
 		require.NoError(t, err)
 		assert.Equal(t, in, out)
+	})
+}
+
+// TestMigrateElasticsearchStrategy covers the second v1->v2 shape change: the
+// legacy `strategy` field was a (single-element) list of `{type: "..."}` objects,
+// while the current schema models it as the bare `type` string.
+func TestMigrateElasticsearchStrategy(t *testing.T) {
+	t.Parallel()
+
+	es := func(strategy resource.PropertyValue) resource.PropertyMap {
+		return resource.PropertyMap{
+			elasticsearchKey: resource.NewObjectProperty(resource.PropertyMap{
+				"strategy": strategy,
+			}),
+		}
+	}
+	strategyOf := func(m resource.PropertyMap) resource.PropertyValue {
+		return m[elasticsearchKey].ObjectValue()["strategy"]
+	}
+
+	t.Run("list of {type} -> string", func(t *testing.T) {
+		t.Parallel()
+		in := es(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{"type": resource.NewStringProperty("autodetect")}),
+		}))
+		out, err := migrateElasticsearchState(context.Background(), in)
+		require.NoError(t, err)
+		got := strategyOf(out)
+		require.True(t, got.IsString())
+		assert.Equal(t, "autodetect", got.StringValue())
+	})
+
+	t.Run("single {type} object -> string", func(t *testing.T) {
+		t.Parallel()
+		in := es(resource.NewObjectProperty(resource.PropertyMap{"type": resource.NewStringProperty("grow_and_shrink")}))
+		out, err := migrateElasticsearchState(context.Background(), in)
+		require.NoError(t, err)
+		got := strategyOf(out)
+		require.True(t, got.IsString())
+		assert.Equal(t, "grow_and_shrink", got.StringValue())
+	})
+
+	t.Run("already a string is left untouched (idempotent)", func(t *testing.T) {
+		t.Parallel()
+		out, err := migrateElasticsearchState(context.Background(), es(resource.NewStringProperty("rolling_all")))
+		require.NoError(t, err)
+		got := strategyOf(out)
+		require.True(t, got.IsString())
+		assert.Equal(t, "rolling_all", got.StringValue())
+	})
+
+	t.Run("empty list is left untouched", func(t *testing.T) {
+		t.Parallel()
+		in := es(resource.NewArrayProperty(nil))
+		out, err := migrateElasticsearchState(context.Background(), in)
+		require.NoError(t, err)
+		assert.True(t, strategyOf(out).IsArray())
 	})
 }
 
@@ -103,4 +160,5 @@ func TestAutoscaleTransformIsWired(t *testing.T) {
 	r := p.Resources["ec_deployment"]
 	require.NotNil(t, r, "ec_deployment must be present in the Resources map")
 	assert.NotNil(t, r.TransformFromState, "TransformFromState must be set on ec_deployment")
+	assert.NotNil(t, r.PreStateUpgradeHook, "PreStateUpgradeHook must be set on ec_deployment")
 }


### PR DESCRIPTION
The first fix attempt ([#830](https://github.com/pulumi/pulumi-ec/pull/830)) addressed the `elasticsearch.autoscale` change but did not update the schema version. A customer on the patched build hit:

```
error: [ERROR] This resource was implemented without an UpgradeState() method, however Terraform was expecting an implementation for version 1 upgrade.

This is always an issue with the Terraform Provider and should be reported to the provider developer.

error: Unable to Upgrade Resource State: This resource was implemented without an UpgradeState() method, however Terraform was expecting an implementation for version 1 upgrade. This is always an issue with the Terraform Provider and should be reported to the provider developer.
```

### Fix

1. Add a **`PreStateUpgradeHook` on `ec_deployment`**  such that state is re-stamped at version 2 after a successful operastion.

2. **Extend the existing state transform** to cover both differences between v1 and v2 schemas:
   - `autoscale`: string (`"true"`/`"false"`) → bool (logic from first fix attempt, unchanged)
   - `strategy`: `[{type: "..."}]` / `{type: "..."}` → the bare `type` string

### Testing

- Unit tests assert both `TransformFromState` and `PreStateUpgradeHook` are attached.
- End-to-end via a C# Automation API repro confirmed `schema_version` 0 and 1 fixtures, plus a combined `autoscale` + `strategy` fixture that failed prior to this PR is now fixed without state surgery.
- `make tfgen` produces no schema diff (runtime-only change).
- Provider builds; `go test` passes; gofmt clean.

Fixes #147.